### PR TITLE
Lua Export Rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,20 @@
 # qb-skillbar
 Skill Bar For QB-Core
 
+# Example
+```lua
+local duration = math.random(2000, 5000)
+local pos = math.random(10, 30)
+local width = math.random(10, 20)
+    
+local success = exports['qb-skillbar']:StartSkillbar(duration, pos, width)
+if success then
+        -- Passed
+else
+        -- Failed
+end
+```
+
 # License
 
     QBCore Framework

--- a/README.md
+++ b/README.md
@@ -1,23 +1,6 @@
 # qb-skillbar
 Skill Bar For QB-Core
 
-# Example
-```lua
-local duration = math.random(2000, 5000)
-
-local pos = math.random(10, 30)
-
-local width = math.random(10, 20)
-    
-local success = exports['qb-skillbar']:StartSkillbar(duration, pos, width)
-
-if success then
-        -- Passed
-else
-        -- Failed
-end
-```
-
 # License
 
     QBCore Framework

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 Skill Bar For QB-Core
 
 # Example
+```lua
 local duration = math.random(2000, 5000)
 
 local pos = math.random(10, 30)
@@ -9,6 +10,7 @@ local pos = math.random(10, 30)
 local width = math.random(10, 20)
     
 local success = exports['qb-skillbar']:StartSkillbar(duration, pos, width)
+```
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,13 @@
 # qb-skillbar
 Skill Bar For QB-Core
 
+# Example
+local duration = math.random(2000, 5000)
+local pos = math.random(10, 30)
+local width = math.random(10, 20)
+    
+local success = exports['qb-skillbar']:StartSkillbar(duration, pos, width)
+
 # License
 
     QBCore Framework

--- a/README.md
+++ b/README.md
@@ -10,6 +10,12 @@ local pos = math.random(10, 30)
 local width = math.random(10, 20)
     
 local success = exports['qb-skillbar']:StartSkillbar(duration, pos, width)
+
+if success then
+        -- Passed
+else
+        -- Failed
+end
 ```
 
 # License

--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ Skill Bar For QB-Core
 
 # Example
 local duration = math.random(2000, 5000)
+
 local pos = math.random(10, 30)
+
 local width = math.random(10, 20)
     
 local success = exports['qb-skillbar']:StartSkillbar(duration, pos, width)

--- a/client/main.lua
+++ b/client/main.lua
@@ -1,80 +1,57 @@
-Skillbar = {}
+local Skillbar = {}
 Skillbar.Data = {}
 Skillbar.Data = {
     Active = false,
     Data = {},
 }
-successCb = nil
-failCb = nil
-
--- NUI Callback's
+local result = nil
 
 RegisterNUICallback('Check', function(data, cb)
-    if successCb ~= nil then
-        Skillbar.Data.Active = false
-        TriggerEvent('progressbar:client:ToggleBusyness', false)
-        if data.success then
-            successCb()
-        else
-            failCb()
-            SendNUIMessage({
-                action = "stop"
-            })
-        end
-    end
+    Skillbar.Data.Active = false
+    TriggerEvent('progressbar:client:ToggleBusyness', false)
+    SendNUIMessage({
+        action = "stop"
+    })
+    result = data.success
 end)
 
-Skillbar.Start = function(data, success, fail)
-    if not Skillbar.Data.Active then
-        Skillbar.Data.Active = true
-        if success ~= nil then
-            successCb = success
-        end
-        if fail ~= nil then
-            failCb = fail
-        end
-        Skillbar.Data.Data = data
-
-        SendNUIMessage({
-            action = "start",
-            duration = data.duration,
-            pos = data.pos,
-            width = data.width,
-        })
-        TriggerEvent('progressbar:client:ToggleBusyness', true)
-    else
-        QBCore.Functions.Notify('Your already doing something..', 'error')
-    end
-end
-
-Skillbar.Repeat = function(data)
-    Skillbar.Data.Active = true
-    Skillbar.Data.Data = data
+function TriggerCheck()
     Citizen.CreateThread(function()
-        Wait(500)
-        SendNUIMessage({
-            action = "start",
-            duration = Skillbar.Data.Data.duration,
-            pos = Skillbar.Data.Data.pos,
-            width = Skillbar.Data.Data.width,
-        }) 
-    end)
-end
-
-Citizen.CreateThread(function()
-    while true do
-        if Skillbar.Data.Active then
+        while Skillbar.Data.Active do
             if IsControlJustPressed(0, 38) then
                 SendNUIMessage({
                     action = "check",
                     data = Skillbar.Data.Data,
                 })
             end
+            Citizen.Wait(1)
         end
-        Citizen.Wait(1)
-    end
-end)
+    end)
+end
 
-function GetSkillbarObject()
-    return Skillbar
+function StartSkillbar(duration, pos, width, callback)
+    if not Skillbar.Data.Active then
+        result = nil
+        Skillbar.Data.Active = true
+
+        Skillbar.Data.Data = {duration = duration, pos = pos, width = width}
+
+        TriggerCheck()
+
+        SendNUIMessage({
+            action = "start",
+            duration = duration,
+            pos = pos,
+            width = width,
+        })
+        TriggerEvent('progressbar:client:ToggleBusyness', true)
+
+        while Skillbar.Data.Active do
+            Citizen.Wait(5)
+        end
+        Citizen.Wait(100)
+        return result
+    else
+        QBCore.Functions.Notify('Your already doing something..', 'error')
+    end
 end

--- a/client/main.lua
+++ b/client/main.lua
@@ -12,22 +12,10 @@ RegisterNUICallback('Check', function(data, cb)
     SendNUIMessage({
         action = "stop"
     })
+    SetNuiFocus(false, false)
+    SetNuiFocusKeepInput(false)
     result = data.success
 end)
-
-function TriggerCheck()
-    Citizen.CreateThread(function()
-        while Skillbar.Data.Active do
-            if IsControlJustPressed(0, 38) then
-                SendNUIMessage({
-                    action = "check",
-                    data = Skillbar.Data.Data,
-                })
-            end
-            Citizen.Wait(1)
-        end
-    end)
-end
 
 function StartSkillbar(duration, pos, width, callback)
     if not Skillbar.Data.Active then
@@ -36,18 +24,18 @@ function StartSkillbar(duration, pos, width, callback)
 
         Skillbar.Data.Data = {duration = duration, pos = pos, width = width}
 
-        TriggerCheck()
-
         SendNUIMessage({
             action = "start",
             duration = duration,
             pos = pos,
             width = width,
         })
+        SetNuiFocus(true, false)
+        SetNuiFocusKeepInput(true)
         TriggerEvent('progressbar:client:ToggleBusyness', true)
 
         while Skillbar.Data.Active do
-            Citizen.Wait(5)
+            Citizen.Wait(100)
         end
         Citizen.Wait(100)
         return result

--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -2,9 +2,10 @@ fx_version 'cerulean'
 game 'gta5'
 
 description 'QB-Skillbar'
-version '1.0.0'
+version '1.1.0'
 
 ui_page "html/index.html"
+
 shared_script '@qb-core/import.lua'
 client_script 'client/main.lua'
 
@@ -12,11 +13,10 @@ files {
     'html/index.html',
     'html/script.js',
     'html/style.css',
-    'html/VerdanaBold.ttf'
 }
 
 exports {
-    'GetSkillbarObject'
+    'StartSkillbar'
 }
 
 dependencies {

--- a/html/script.js
+++ b/html/script.js
@@ -1,7 +1,12 @@
+var POS
+var WIDTH
+
 $(document).ready(function(){
     Skillbar = {};
 
     Skillbar.Start = function(data) {
+        POS = data.pos
+        WIDTH = data.width
         $(".bar-check").css({"right": data.pos + "%"});
         $(".bar-check").css({"width": data.width + "%"});
         $(".bar-container").fadeIn('fast', function() {
@@ -34,12 +39,14 @@ $(document).ready(function(){
         $(".bar-container").fadeOut('fast', function() {
             $(".bar-total").css("width", 0);
         })
+        POS = null
+        WIDTH = null
     }
 
-    Skillbar.Check = function(data) {
+    Skillbar.Check = function() {
         var Percentage = (($(".bar-total").width() / $(".bar-container").width()) * 100);
-        var Check = 100 - data.data.pos
-        var Minimum = Check - (data.data.width)
+        var Check = 100 - POS
+        var Minimum = Check - WIDTH
 
         $(".bar-total").stop();
         if (Percentage + 2 >= Minimum && Percentage - 2 <= Check) {
@@ -73,9 +80,13 @@ $(document).ready(function(){
             case "stop":
                 Skillbar.Stop();
                 break;
-            case "check":
-                Skillbar.Check(event.data);
-                break;
         }
     });
+
+    document.onkeydown = function (data) {
+        let key_pressed = data.code;
+        if (key_pressed == 'KeyE') {
+            Skillbar.Check()
+        }
+    };
 });

--- a/html/style.css
+++ b/html/style.css
@@ -1,4 +1,4 @@
-@import url('https://fonts.googleapis.com/css2?family=Poppins:wght@100&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Urbanist:wght@100&display=swap');
 
 body {
     padding: 0;
@@ -42,7 +42,7 @@ body {
 
 .bar-check > span {
     color: white;
-    font-family: 'Poppins', sans-serif;
+    font-family: 'Urbanist', sans-serif;
     font-weight: 700;
     font-size: 1.3vh;
     font-weight: bold;


### PR DESCRIPTION
As per issue #6 

- Mostly a rewrite of the client lua
- Allows for an 1 line export to trigger the skillbar
`local success = exports['qb-skillbar']:StartSkillbar(duration, pos, width)`
- Added example into Readme
- Remove the lua loop checking for ControlPressed and instead move into js with keydown event
- Fixed PR #5 by also changing the font in  .bar-check > span