### PR TITLE
Fix for Warning: Could not find file

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -12,7 +12,6 @@ files {
     'html/index.html',
     'html/script.js',
     'html/style.css',
-    'html/VerdanaBold.ttf'
 }
 
 dependencies {


### PR DESCRIPTION
This fixes the console warning being thrown when starting the script.