### PR TITLE
Added 'amount' argument to the skillbar

### DIFF
--- a/client/main.lua
+++ b/client/main.lua
@@ -44,7 +44,7 @@ Skillbar.Start = function(data, success, fail)
             failCb = fail
         end
         Skillbar.Data.Data = data
-        Skillbar.Data.Data.amount = data.amount or 1 -- Set a default value of 1 if 'amount' is not provided
+        Skillbar.Data.Data.amount = data.amount or 1
         Skillbar.Data.Completed = 0
 
         SendNUIMessage({

--- a/client/main.lua
+++ b/client/main.lua
@@ -5,6 +5,7 @@ Skillbar.Data = {}
 Skillbar.Data = {
     Active = false,
     Data = {},
+    Completed = 0,
 }
 successCb = nil
 failCb = nil
@@ -16,7 +17,13 @@ RegisterNUICallback('Check', function(data, cb)
         Skillbar.Data.Active = false
         TriggerEvent('progressbar:client:ToggleBusyness', false)
         if data.success then
-            successCb()
+            Skillbar.Data.Completed = Skillbar.Data.Completed + 1
+            if Skillbar.Data.Completed >= Skillbar.Data.Data.amount then
+                Skillbar.Data.Completed = 0
+                successCb()
+            else
+                Skillbar.Repeat(Skillbar.Data.Data)
+            end
         else
             failCb()
             SendNUIMessage({
@@ -37,6 +44,7 @@ Skillbar.Start = function(data, success, fail)
             failCb = fail
         end
         Skillbar.Data.Data = data
+        Skillbar.Data.Completed = 0
 
         SendNUIMessage({
             action = "start",
@@ -46,7 +54,7 @@ Skillbar.Start = function(data, success, fail)
         })
         TriggerEvent('progressbar:client:ToggleBusyness', true)
     else
-        QBCore.Functions.Notify('Your already doing something..', 'error')
+        QBCore.Functions.Notify('You are already doing something..', 'error')
     end
 end
 

--- a/client/main.lua
+++ b/client/main.lua
@@ -44,6 +44,7 @@ Skillbar.Start = function(data, success, fail)
             failCb = fail
         end
         Skillbar.Data.Data = data
+        Skillbar.Data.Data.amount = data.amount or 1 -- Set a default value of 1 if 'amount' is not provided
         Skillbar.Data.Completed = 0
 
         SendNUIMessage({


### PR DESCRIPTION
An 'amount' argument has been added to the Skillbar.Start function, allowing users to specify the number of times a skillbar must be completed before being marked as done. The skillbar will now repeat itself until the specified amount is reached. If the player fails any skillbar during the process, the skillbar will stop, and the fail callback will be triggered.

For example:
```lua
Skillbar.Start({
    duration = math.random(2500, 5000),
    pos = math.random(10, 30),
    width = math.random(10, 20),
    amount = 3,
}, successCallback, failCallback)
```

These changes improve the functionality and user experience of the QB skillbar by adding more control.

- Have you personally loaded this code into an updated qbcore project and checked all it's functionality?
Yes, I've tested the code thoroughly to ensure it works as intended.
- Does your code fit the style guidelines? [yes/no]
Yes, I have made sure to follow the qbcore project's style guidelines to maintain consistency and readability.
- Does your PR fit the contribution guidelines? [yes/no]
Yes, my pull request follows the contribution guidelines, providing a clear description and explanation of the changes made.
